### PR TITLE
fix: _getCmdPoints中的cmds可能是空数组

### DIFF
--- a/src/layaAir/laya/display/GraphicsBounds.ts
+++ b/src/layaAir/laya/display/GraphicsBounds.ts
@@ -117,12 +117,12 @@ export class GraphicsBounds {
         rst = this._temp || (this._temp = []);
 
         rst.length = 0;
-        if (!cmds && this._graphics._one != null) {
+        if ((!cmds || cmds.length == 0) && this._graphics._one != null) {
             GraphicsBounds._tempCmds.length = 0;
             GraphicsBounds._tempCmds.push(this._graphics._one);
             cmds = GraphicsBounds._tempCmds;
         }
-        if (!cmds) return rst;
+        if (!cmds || cmds.length == 0) return rst;
 
         var matrixs: any[] = GraphicsBounds._tempMatrixArrays;
         matrixs.length = 0;


### PR DESCRIPTION
_getCmdPoints中的cmds可能是空数组, 需要考虑这种边界情况